### PR TITLE
cli: Add new command to run huey

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Now open http://localhost:8000
 
 We use [huey](https://huey.readthedocs.io/en/latest/) to run background jobs. This requires you to run a second process, in parallel to TeamVault itself. You can launch it via `manage.py`:
 
-    teamvault/manage.py run_huey
+    teamvault run_huey
 
 ## Release process
 1. Install the "build" and "twine" packages via pip

--- a/teamvault/cli.py
+++ b/teamvault/cli.py
@@ -49,6 +49,10 @@ def build_parser():
     parser_run.add_argument('--bind', nargs='?', help='define bind, default is 127.0.0.1:8000')
     parser_run.set_defaults(func=run)
 
+    # teamvault run_huey
+    parser_run = subparsers.add_parser("run_huey")
+    parser_run.set_defaults(func=run_huey)
+
     # teamvault setup
     parser_setup = subparsers.add_parser("setup")
     parser_setup.set_defaults(func=setup)
@@ -91,6 +95,10 @@ def run(pargs):
         shell=True,
     )
     gunicorn.communicate()
+
+
+def run_huey(pargs):
+    execute_from_command_line(["", "run_huey"])
 
 
 def setup(pargs):


### PR DESCRIPTION
manage.py is only available for devs. Normal installations need a new entry point for huey.