### PR TITLE
Fixed search result element height

### DIFF
--- a/teamvault/static/scss/search.scss
+++ b/teamvault/static/scss/search.scss
@@ -93,6 +93,14 @@
   }
 }
 
+#search-modal-results {
+  height: 90vh;
+}
+
+.search-modal-result-content-extras {
+  font-size: 0.75em;
+}
+
 .search-modal-result-content {
   display: flex;
   flex: 1 1 auto;

--- a/teamvault/static/scss/search.scss
+++ b/teamvault/static/scss/search.scss
@@ -97,9 +97,6 @@
   height: 90vh;
 }
 
-.search-modal-result-content-extras {
-  font-size: 0.75em;
-}
 
 .search-modal-result-content {
   display: flex;


### PR DESCRIPTION
According to [TOOLTIME-180](https://seibertmedia-cloud.atlassian.net/browse/TOOLTIME-180) search result element does not jump in height when searching and has fixed height instead.