### PR TITLE
Display when secret deleted

### DIFF
--- a/teamvault/apps/secrets/templates/secrets/secret_detail.html
+++ b/teamvault/apps/secrets/templates/secrets/secret_detail.html
@@ -51,6 +51,10 @@
                                     {% endblock %}
                                 </div>
                             </div>
+                        {% elif secret_deleted %}
+                            <div class="alert alert-danger text-center mb-0">
+                                {% trans "This secret has been deleted." %}
+                            </div>
                         {% else %}
                             <div class="alert alert-danger text-center mb-0">
                                 {% trans "You are not allowed to read this secret." %}

--- a/teamvault/apps/secrets/views.py
+++ b/teamvault/apps/secrets/views.py
@@ -322,6 +322,7 @@ class SecretDetail(DetailView):
         context['content_type'] = CONTENT_TYPE_IDENTIFIERS[secret.content_type]
         context['readable'] = secret.is_readable_by_user(self.request.user)
         context['shareable'] = secret.is_shareable_by_user(self.request.user)
+        context['secret_deleted'] = True if secret.status == Secret.STATUS_DELETED else False
         context['secret_url'] = reverse(
             'api.secret-revision_data',
             kwargs={'hashid': secret.current_revision.hashid},


### PR DESCRIPTION
Add: Secret now displays if it has been deleted instead of "You are not allowed ..." message. [TOOLTIME-88](https://seibertmedia-cloud.atlassian.net/browse/TOOLTIME-88)