### PR TITLE
Colorful Secrets

### DIFF
--- a/teamvault/apps/secrets/templates/secrets/detail_content/_js.html
+++ b/teamvault/apps/secrets/templates/secrets/detail_content/_js.html
@@ -49,8 +49,8 @@
         revBtn.querySelector('i').classList.add('fa-shield')
 
         let passwordField = document.getElementById('password-field')
-        passwordField.value = password
-        passwordField.disabled = false
+        const passwordHTML = teamvault.getColorfulPasswordHTML(password);
+        passwordField.replaceChildren(...passwordHTML)
     }
 
     function unreveal() {
@@ -63,8 +63,7 @@
         revBtn.querySelector('i').classList.add('fa-magic')
 
         let passwordField = document.getElementById('password-field')
-        passwordField.value = secret_placeholder
-        passwordField.disabled = true
+        passwordField.replaceChildren(document.createTextNode(secret_placeholder))
     }
 
     function initProgressBar() {

--- a/teamvault/apps/secrets/templates/secrets/detail_content/password.html
+++ b/teamvault/apps/secrets/templates/secrets/detail_content/password.html
@@ -4,8 +4,7 @@
 
 {% block secret_content %}
     <div class="input-group input-group-lg">
-        <input type="text" id="password-field" class="form-control" value="{{ placeholder }}"
-               autocomplete="off" disabled>
+        <div id="password-field" class="input-group-text form-control overflow-auto">{{ placeholder }}</div>
         <div class="vr mx-1"></div>
         <button class="btn btn-light" id="copy-password" type="button"
                 data-bs-toggle="tooltip"

--- a/teamvault/apps/secrets/templates/secrets/detail_content/password.html
+++ b/teamvault/apps/secrets/templates/secrets/detail_content/password.html
@@ -102,8 +102,19 @@
         })
 
         function largeType(password) {
+            const colorfulPasswordHTML = password.split("").map(character => {
+                // digits
+                if(/\d/.test(character)) return `<span class="text-danger">${character}</span>`;
+
+                // everything else (special characters)
+                if(/\W/.test(character)) return `<span class="text-primary">${character}</span>`;
+
+                // characters
+                return `<span>${character}</span>`;
+            }).join("");
+
             largeTypeElement.classList.remove('invisible')
-            largeTypeElement.innerHTML = `<div>${password}</div>`
+            largeTypeElement.innerHTML = `<div>${colorfulPasswordHTML}</div>`
 
             // TODO: Replace bigtext with something non-jquery
             $('.large-type').bigtext();

--- a/teamvault/apps/secrets/templates/secrets/detail_content/password.html
+++ b/teamvault/apps/secrets/templates/secrets/detail_content/password.html
@@ -102,19 +102,22 @@
         })
 
         function largeType(password) {
-            const colorfulPasswordHTML = password.split("").map(character => {
-                // digits
-                if(/\d/.test(character)) return `<span class="text-danger">${character}</span>`;
+            const container = document.createElement("div");
 
-                // everything else (special characters)
-                if(/\W/.test(character)) return `<span class="text-primary">${character}</span>`;
+            password.split("").forEach(character => {
+                const newSpan = document.createElement("span");
+                newSpan.innerText = character;
 
-                // characters
-                return `<span>${character}</span>`;
-            }).join("");
+                if("a" <= character && character <= "z") newSpan.classList.add("text-secondary");
+                else if("A" <= character && character <= "Z") newSpan.classList.add("text-white");
+                else if("0" <= character && character <= "9") newSpan.classList.add("text-danger");
+                else newSpan.classList.add("text-primary");
+                
+                container.appendChild(newSpan)
+            })
 
+            largeTypeElement.appendChild(container);
             largeTypeElement.classList.remove('invisible')
-            largeTypeElement.innerHTML = `<div>${colorfulPasswordHTML}</div>`
 
             // TODO: Replace bigtext with something non-jquery
             $('.large-type').bigtext();

--- a/teamvault/apps/secrets/templates/secrets/detail_content/password.html
+++ b/teamvault/apps/secrets/templates/secrets/detail_content/password.html
@@ -102,20 +102,9 @@
         })
 
         function largeType(password) {
+            const passwordHTML = teamvault.getColorfulPasswordHTML(password)
             const container = document.createElement("div");
-
-            password.split("").forEach(character => {
-                const newSpan = document.createElement("span");
-                newSpan.innerText = character;
-
-                if("a" <= character && character <= "z") newSpan.classList.add("text-secondary");
-                else if("A" <= character && character <= "Z") newSpan.classList.add("text-white");
-                else if("0" <= character && character <= "9") newSpan.classList.add("text-danger");
-                else newSpan.classList.add("text-primary");
-                
-                container.appendChild(newSpan)
-            })
-
+            container.append(...passwordHTML)
             largeTypeElement.appendChild(container);
             largeTypeElement.classList.remove('invisible')
 

--- a/teamvault/static/js/utils.js
+++ b/teamvault/static/js/utils.js
@@ -15,3 +15,20 @@ export function scrollIfNeeded(el, containerEl) {
     }
   }
 }
+
+/**
+ * @param {string} password 
+ * @returns {HTMLSpanElement[]} div containing the colored password 
+ */
+export const getColorfulPasswordHTML = (password) =>
+  password.split("").map(character => {
+    const newSpan = document.createElement("span");
+    newSpan.innerText = character;
+
+    if ("a" <= character && character <= "z") newSpan.classList.add("pw-lowercase");
+    else if ("A" <= character && character <= "Z") newSpan.classList.add("pw-uppercase");
+    else if ("0" <= character && character <= "9") newSpan.classList.add("pw-number");
+    else newSpan.classList.add("pw-symbol");
+
+    return newSpan;
+  });

--- a/teamvault/static/scss/secrets.scss
+++ b/teamvault/static/scss/secrets.scss
@@ -2,10 +2,27 @@
 @import '@fortawesome/fontawesome-free/scss/mixins';
 @import '@fortawesome/fontawesome-free/scss/variables';
 
+.pw-uppercase {
+  color: #999999
+}
+.pw-lowercase {
+  color: white;
+}
+.pw-number {
+  color: #ff3333;
+}
+.pw-symbol {
+  color: #5982ff;
+}
 
 #password-field {
   font-family: "Ubuntu Mono", monospace;
   text-align: center;
+  display: block;
+
+  .pw-lowercase {
+    color: black;
+  }
 }
 
 .large-type {


### PR DESCRIPTION
(did a git oopsie😐 - old PR: #167 )

recap: 
- I like how secrets are colored in 1password and implemented it for Teamvault
- it differentiates between lowercase, uppercase, numbers and symbols (everything that is not cought in the previous categories)
- Using `innerHTML` turned out to be an easy code injection -> now adding elements programmatically
- colors can be configured in secrets.scss

up for discussion: 
- I replaced the input with a div, to allow use of spans to color the secret - Does the input have any advantages over a div?
- colors ok?