### PR TITLE
Darkmode

### DIFF
--- a/teamvault/apps/accounts/templates/accounts/login.html
+++ b/teamvault/apps/accounts/templates/accounts/login.html
@@ -5,10 +5,10 @@
 {% block title %}{% trans "Login" %}{% endblock %}
 {% block super_content %}
     <div class="d-flex justify-content-center align-items-center vh-100">
-        <form id="loginform" class="text-center rounded-5 bg-white shadow-lg p-5" role="form" method="POST" style="width: 25rem">
+        <form id="loginform" class="text-center rounded-5 bg-body shadow-lg p-5" role="form" method="POST" style="width: 25rem">
             {% csrf_token %}
             <div class="mb-5">
-                <span class="fs-1 text-black">Team</span><span class="fs-1 text-accent">Vault</span>
+                <span class="fs-1 text-body">Team</span><span class="fs-1 text-accent">Vault</span>
             </div>
             {% if form.errors %}
                 <p class="alert alert-danger text-break">{% trans "Your username and password didn't match. Please try again." %}</p>

--- a/teamvault/apps/accounts/templates/accounts/logout.html
+++ b/teamvault/apps/accounts/templates/accounts/logout.html
@@ -6,9 +6,9 @@
 
 {% block super_content %}
     <div class="d-flex justify-content-center align-items-center vh-100">
-        <div class="text-center rounded-5 bg-white shadow-lg p-5" style="width: 25rem">
+        <div class="text-center rounded-5 bg-body shadow-lg p-5" style="width: 25rem">
             <div class="mb-2">
-                <span class="fs-1 text-black ">Team</span><span class="fs-1 text-accent">Vault</span>
+                <span class="fs-1 text-body ">Team</span><span class="fs-1 text-accent">Vault</span>
             </div>
             <div class="mb-4">
                 <span>{% trans "Logged out." %}</span>

--- a/teamvault/apps/secrets/templates/secrets/addedit_content/password.html
+++ b/teamvault/apps/secrets/templates/secrets/addedit_content/password.html
@@ -20,9 +20,9 @@
                         <i class="far fa-star text-muted"></i>
                     {% endfor %}
                 </span>
-                <button class="btn btn-outline-dark" id="id_pwgen" type="button"
+                <button class="btn border btn-outline-secondary" id="id_pwgen" type="button"
                         title="{% trans "Generate random password" %}">
-                    <i class="fa fa-refresh fa-fw align-middle"></i>
+                    <i class="fa fa-refresh fa-fw align-middle text-body"></i>
                 </button>
             </div>
         </div>

--- a/teamvault/apps/secrets/templates/secrets/secret_search.html
+++ b/teamvault/apps/secrets/templates/secrets/secret_search.html
@@ -7,10 +7,10 @@
                 <form class="d-flex align-items-center border border-2" action="{% url 'secrets.secret-list' %}" role="search"
                       method="GET">
                     <label id="search-modal-label" for="search-modal-input">
-                        <i class="fa fa-search fa-fw"></i>
+                        <i class="fa fa-search fa-fw text-body"></i>
                     </label>
                     <input id="search-modal-input" name="search" placeholder="{% trans "Search secrets..." %}"
-                           type="text" class="form-control bg-white" value="{{ request.GET.search }}">
+                           type="text" class="form-control" value="{{ request.GET.search }}">
 
                     <span id="search-indicator" class="spinner-border spinner-border-sm align-middle"
                           role="status" aria-hidden="true" style="visibility: hidden"></span>

--- a/teamvault/static/scss/base.scss
+++ b/teamvault/static/scss/base.scss
@@ -13,6 +13,7 @@
 @import "./scrollbar";
 @import "./search";
 @import "./secrets";
+@import "./card.scss";
 
 @import "./fontawesome";
 @import "./select2";
@@ -23,7 +24,7 @@ body {
 
 a {
   text-decoration: none;
-  color: #377fae;
+  color: var(--bs-info);
 }
 
 .background {
@@ -42,7 +43,7 @@ a {
 }
 
 h1 {
-  color: #505050;
+  color: var(--text-body);
 
   > .badge {
     vertical-align: top;
@@ -92,10 +93,27 @@ kbd {
   }
 }
 
-form {
-  input, textarea {
-    &:placeholder-shown {
-      background-color: var(--bs-gray-100);
+[data-bs-theme="dark"] {
+  .btn-light {
+    color: var(--bs-light);
+    background-color: var(--bs-secondary-bg);
+    border-color: var(--bs-secondary-bg);
+    border-width: 1px;
+    transition: filter .15s ease-in-out;
+
+    &:hover {
+      filter: brightness(1.2);
     }
+    &:active {
+      filter: brightness(1.4);
+      background-color: var(--bs-secondary-bg);
+      border-color: var(--bs-secondary-bg);
+      color: var(--bs-light);
+    }
+  }
+  
+  // bg-color for filter chips
+  .bg-secondary-subtle {
+    background-color: #37383b!important;
   }
 }

--- a/teamvault/static/scss/card.scss
+++ b/teamvault/static/scss/card.scss
@@ -1,0 +1,4 @@
+// custom dark credit card background
+[data-bs-theme="dark"] .jp-card-front {
+  background-color: $secondary !important;
+}

--- a/teamvault/static/scss/secrets.scss
+++ b/teamvault/static/scss/secrets.scss
@@ -35,7 +35,7 @@
     padding: 0.25rem;
 
     a {
-      color: #325063;
+      color: var(--bs-info);
     }
 
     &:first-child {
@@ -59,7 +59,7 @@
 
 .secret-meta {
   td {
-    color: #606060;
+    color: var(--bs-body);
 
     &:first-child {
       color: #708999;
@@ -115,4 +115,9 @@
 
 .col-form-label, .form-label {
   font-weight: 500;
+}
+
+// custom hover for "generate random secret button"
+[data-bs-theme="light"] #id_pwgen:hover {
+  background: #ddd;
 }

--- a/teamvault/static/scss/select2.scss
+++ b/teamvault/static/scss/select2.scss
@@ -1,29 +1,62 @@
-@import 'select2/src/scss/core.scss';
+@import "select2/src/scss/core.scss";
 @import "select2-bootstrap-5-theme/dist/select2-bootstrap-5-theme.css";
 
 /* Hide selected options in choices */
-.select2-results__option[aria-selected=true] {
+.select2-results__option[aria-selected="true"] {
   display: none;
 }
 
-.select2-container--bootstrap-5.select2-container--open .select2-selection {
-  box-shadow: none;
-}
+.select2-container--bootstrap-5 {
+  .select2-selection {
+    background-color: var(--bs-body-bg);
 
-.select2-selection.select2-selection--multiple {
-  background-color: var(--bs-gray-100);
-  padding: 1rem;
+    .select2-selection__rendered {
+      color: var(--bs-body-color);
+    }
 
-  .select2-selection__rendered {
-    display: flex;
+    .select2-selection__clear {
+      color: var(--bs-body-color);
+    }
+
+    // Fix misaligned clear button
+    &--single .select2-selection__clear {
+      position: absolute;
+    }
+
+    &__choice__remove {
+      cursor: pointer;
+    }
+
+    &.select2-selection--multiple {
+      padding: 1rem;
+
+      .select2-selection__rendered {
+        display: flex;
+      }
+    }
   }
-}
-
-// Fix misaligned clear button
-.select2-container .select2-selection--single .select2-selection__clear {
-  position: absolute;
-}
-
-.select2-selection__choice__remove {
-  cursor: pointer;
+  &.select2-container--open .select2-selection {
+    box-shadow: none;
+  }
+  .select2-dropdown {
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    .select2-search {
+      .select2-search__field {
+        color: var(--bs-body-color);
+        background-color: initial;
+      }
+    }
+    .select2-results {
+      ul.select2-results__options {
+        li.select2-results__option {
+          &.select2-results__option--highlighted {
+            color: var(--bs-body-color);
+            background: var(--bs-body-bg);
+            filter: brightness(0.8);
+          }
+        }
+      }
+    }
+  }
 }

--- a/teamvault/templates/base.html
+++ b/teamvault/templates/base.html
@@ -18,7 +18,7 @@
     {% block head %}{% endblock %}
 </head>
 
-<body data-bs-no-jquery>
+<body data-bs-no-jquery {% if request.COOKIES.theme == 'dark' %}data-bs-theme="dark"{% else %}data-bs-theme="light"{% endif %}>
 <script>
     const tooltipOptions = {container: 'body', html: true, trigger: 'hover'}
 

--- a/teamvault/templates/base_nav.html
+++ b/teamvault/templates/base_nav.html
@@ -83,6 +83,17 @@
                     </div>
                 </div>
             {% endif %}
+
+            <!-- Theme toggle -->
+            <div class="col-12 col-lg-auto my-2 me-lg-4 mb-3 mb-lg-2 d-flex justify-content-center align-items-center">
+                <button class="btn btn-outline-primary bg-transparent btn-sm border-0"
+                    role="button"
+                    onclick="toggleTheme()"
+                    aria-expanded="false">
+                    <i class="fa {% if request.COOKIES.theme == 'dark' %} fa-moon {% else %} fa-sun {% endif %} fa-fw text-white fs-5 lh-1" id="theme-icon"></i>
+                </button> 
+            </div>
+
             <!-- User actions -->
             <div class="col-12 col-lg-auto my-2 mb-3 mb-lg-2 d-flex justify-content-center justify-content-lg-end align-items-center">
                 <div class="dropdown-center">
@@ -112,5 +123,26 @@
         </div>
     </div>
 </header>
+
+<script>
+    let theme = {% if request.COOKIES.theme == 'dark' %} "dark" {% else %} "light" {% endif %}; // directly using`request.COOKIES.theme` could lead to a code injection
+
+    function toggleTheme() {
+        // toggle theme
+        theme = theme === "light" ? "dark" : "light";
+        document.body.setAttribute("data-bs-theme", theme)
+
+        // change icon
+        const toggleButton = document.getElementById("theme-icon");
+        toggleButton.classList.remove("fa-sun", "fa-moon")
+        toggleButton.classList.add(theme === "dark" ? "fa-moon" : "fa-sun")
+
+        // update cookie
+        const d = new Date();
+        d.setTime(d.getTime() + 25_920_000_000);
+        let expires = "expires="+ d.toUTCString();
+        document.cookie = `theme=${theme}; expires=${expires}; path=/`;
+    }
+</script>
 
 {% include 'secrets/secret_search.html' %}

--- a/teamvault/templates/base_nav.html
+++ b/teamvault/templates/base_nav.html
@@ -47,8 +47,8 @@
                         data-bs-target="#search-modal">
                     <span><i class="fa fa-search fa-fw"></i> {% translate "Search" %}</span>
                     <span>
-                        <kbd>{% translate "CTRL" %}<span class="mx-1">/</span>⌘</kbd>
-                        <kbd>K</kbd>
+                        <kbd class="bg-transparent border border-secondary">{% translate "CTRL" %}<span class="mx-1">/</span>⌘</kbd>
+                        <kbd class="bg-transparent border border-secondary">K</kbd>
                     </span>
                 </button>
             </div>


### PR DESCRIPTION
# Implemented darkmode for TeamVault

- State is tracked via a cookie (theme=light/dark)
- cookie sets `data-bs-theme="light/dark"` on body to let bootstrap handle most of the theming work
- light theme is default, if no cookie is set 
- theme toggle is currently a button in nav bar (i also experimented with a toggle in the profile pic drop down):
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e7a577de-07f8-4127-926e-7eb4d827efc8">

I visited evey page and every menu i have access to
I could not test anything related to groups or default (nonadmin) users as i dont know how to create those

## Some impressions:

<img width="572" alt="image" src="https://github.com/user-attachments/assets/53a400d2-ea59-4830-83d1-551fda3451de">
<img width="1917" alt="image" src="https://github.com/user-attachments/assets/6438d687-8f92-44a6-a272-256876866a7a">
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d46713a2-6b3a-4f68-8864-03393eab4321">
<img width="754" alt="image" src="https://github.com/user-attachments/assets/ebda921a-33e9-4268-ac84-87578c973415">
