### PR TITLE
Fix API functionality with the way secrets are now saved in the database (JSON) TOOLTIME-60 (https://jira.intra.seibert.group/browse/TOOLTIME-60)

### DIFF
--- a/teamvault/apps/secrets/api/serializers.py
+++ b/teamvault/apps/secrets/api/serializers.py
@@ -1,5 +1,4 @@
 from base64 import b64decode
-from json import dumps
 
 from django.contrib.auth.models import Group, User
 from django.db import models
@@ -139,7 +138,7 @@ class SecretSerializer(serializers.HyperlinkedModelSerializer):
         try:
             content_type = validated_data.pop('content_type')
         except KeyError:
-            raise serializers.ValidationError(_(f'Missing required field content type'))
+            raise serializers.ValidationError(_('Missing required field content type'))
         data = _extract_data(validated_data, content_type)
         if not data:
             raise serializers.ValidationError("missing secret field (e.g. 'password')")
@@ -205,11 +204,11 @@ class SecretSerializer(serializers.HyperlinkedModelSerializer):
             'last_read',
             'name',
             'needs_changing_on_leave',
+            'secret_data',
             'status',
             'url',
             'username',
             'web_url',
-            'secret_data',
         )
         read_only_fields = (
             'content_type',

--- a/teamvault/apps/secrets/api/serializers.py
+++ b/teamvault/apps/secrets/api/serializers.py
@@ -122,7 +122,7 @@ class SecretSerializer(serializers.HyperlinkedModelSerializer):
         view_name='api.secret_detail',
     )
     content_type = serializers.ChoiceField(
-        choices=ConentType.choices,
+        choices=ContentType.choices,
         required=True
     )
     created_by = serializers.SlugRelatedField(

--- a/teamvault/apps/secrets/api/serializers.py
+++ b/teamvault/apps/secrets/api/serializers.py
@@ -43,17 +43,17 @@ REQUIRED_CC_FIELDS = {'holder', 'expiration_month', 'expiration_year', 'number',
 def _extract_data(validated_data, content_type: Secret.CONTENT_CHOICES):
     data = {}
     secret_data = validated_data.get('secret_data')
-    if content_type == 'password':
+    if content_type == Secret.CONTENT_PASSWORD:
         for attr in ['password', 'otp_key_data']:
             if attr in secret_data:
                 data[attr] = secret_data[attr]
-    elif content_type == 'cc':
+    elif content_type == Secret.CONTENT_CC:
         for attr in ['holder', 'expiration_month', 'expiration_year', 'number', 'security_code', 'password']:
             try:
                 data[attr] = secret_data[attr]
             except KeyError:
                 raise serializers.ValidationError(_(f'Missing required credit card field {attr}'))
-    elif content_type == 'file':
+    elif content_type == Secret.CONTENT_FILE:
         if 'filename' in secret_data:
             data['filename'] = secret_data['filename']
         if 'file' in secret_data:

--- a/teamvault/apps/secrets/api/serializers.py
+++ b/teamvault/apps/secrets/api/serializers.py
@@ -58,9 +58,6 @@ def _extract_data(validated_data, content_type: Secret.CONTENT_CHOICES):
             data['filename'] = secret_data['filename']
         if 'file' in secret_data:
             data['file'] = b64decode(secret_data.pop('file').encode('ascii'))
-        for attr in ['file', 'filename']:
-            if attr in secret_data:
-                data[attr] = secret_data[attr]
     return data
 
 

--- a/teamvault/apps/secrets/api/serializers.py
+++ b/teamvault/apps/secrets/api/serializers.py
@@ -11,7 +11,7 @@ from rest_framework.reverse import reverse
 from ..models import Secret, SecretRevision, SharedSecretData
 
 
-class ConentType(models.TextChoices):
+class ContentType(models.TextChoices):
     PASSWORD = 'password', _('Password')
     CC = 'cc', _('Credit Card')
     FILE = 'file', _('File')

--- a/teamvault/apps/secrets/forms.py
+++ b/teamvault/apps/secrets/forms.py
@@ -149,8 +149,7 @@ class PasswordForm(SecretForm):
             as_url, data_params = extract_url_and_params(cleaned_otp_key_data)
         except Exception:
             raise forms.ValidationError(_('OTP key should have a format like this: ___?secret=___&digits=___ ...'))
-        secret = data_params['secret'][0] if 'secret' in data_params else ''
-
+        secret = data_params['secret'] if 'secret' in data_params else ''
         is_valid_b32_string(secret)
         return cleaned_otp_key_data
 

--- a/teamvault/apps/secrets/models.py
+++ b/teamvault/apps/secrets/models.py
@@ -260,9 +260,9 @@ class Secret(HashIDModel):
             data = request.session["otp_key_data"]
         else:
             data = self.get_data(request.user)
-        otp_key = data['otp_key']
+        otp_key = data['secret']
         digits = int(data['digits'])
-        request.session["otp_key_data"] = {'otp_key': otp_key, 'digits': digits}
+        request.session["otp_key_data"] = {'secret': otp_key, 'digits': digits}
         totp = TOTP(otp_key, digits=digits)
         return totp.now()
 
@@ -409,7 +409,7 @@ class Secret(HashIDModel):
         # save the length before encoding so multi-byte characters don't
         # mess up the result
         set_password = "password" in plaintext_data and self.content_type == Secret.CONTENT_PASSWORD
-        set_otp = "otp_key" in plaintext_data
+        set_otp = "secret" in plaintext_data
         plaintext_length = len(plaintext_data)
         f = Fernet(settings.TEAMVAULT_SECRET_KEY)
         if set_password:

--- a/teamvault/apps/secrets/utils.py
+++ b/teamvault/apps/secrets/utils.py
@@ -19,12 +19,9 @@ def serialize_add_edit_data(cleaned_data, secret):
         cleaned_data_as_url, data_params = extract_url_and_params(cleaned_data["otp_key_data"])
         if cleaned_data.get("password"):
             plaintext_data['password'] = cleaned_data['password']
-        if data_params.get("secret"):
-            plaintext_data["otp_key"] = data_params["secret"][0]
-        if data_params.get("digits"):
-            plaintext_data["digits"] = data_params["digits"][0]
-        if data_params.get("algorithm"):
-            plaintext_data["algorithm"] = data_params["algorithm"][0]
+        for attr in ['secret', 'digits', 'algorithm']:
+            if data_params.get(attr):
+                plaintext_data[attr] = data_params[attr][0]
     elif secret.content_type == Secret.CONTENT_FILE:
         plaintext_data["file_content"] = cleaned_data['file'].read().decode("utf-8")
         secret.filename = cleaned_data['file'].name

--- a/teamvault/apps/secrets/utils.py
+++ b/teamvault/apps/secrets/utils.py
@@ -10,6 +10,8 @@ from .models import Secret
 def extract_url_and_params(data):
     data_as_url = urlparse(data)
     data_params = parse_qs(data_as_url.query)
+    for key, value in data_params.items():
+        data_params[key] = value[0]
     return data_as_url, data_params
 
 
@@ -21,7 +23,7 @@ def serialize_add_edit_data(cleaned_data, secret):
             plaintext_data['password'] = cleaned_data['password']
         for attr in ['secret', 'digits', 'algorithm']:
             if data_params.get(attr):
-                plaintext_data[attr] = data_params[attr][0]
+                plaintext_data[attr] = data_params[attr]
     elif secret.content_type == Secret.CONTENT_FILE:
         plaintext_data["file_content"] = cleaned_data['file'].read().decode("utf-8")
         secret.filename = cleaned_data['file'].name


### PR DESCRIPTION
Changed secret API to accept JSON field with secret data except for fields like cardholder, expiry year, ... etc.