### PR TITLE
Add management command to generate fake users and secrets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ version = '1.0.0rc6'  # Also change in teamvault/__version__.py
 dev = [
     "django-stubs~=5.1",
     "djangorestframework-stubs~=3.15",
+    "faker",
 ]
 
 [project.scripts]

--- a/teamvault/apps/secrets/management/commands/create_fake_data.py
+++ b/teamvault/apps/secrets/management/commands/create_fake_data.py
@@ -1,19 +1,23 @@
+import json
 import random
 from datetime import timedelta
+from hashlib import sha256
+
+from cryptography.fernet import Fernet
+from django.conf import settings
+from django.contrib.auth.models import Group, User
 from django.core.management.base import BaseCommand
 from django.utils import timezone
-from django.contrib.auth.models import User, Group
+
 from teamvault.apps.secrets.models import Secret, SecretRevision, SharedSecretData
-from faker import Faker
-from django.conf import settings
-from cryptography.fernet import Fernet
-import json
-from hashlib import sha256
+
 
 class Command(BaseCommand):
     help = 'Create fake users and secrets'
 
     def handle(self, *args, **kwargs):
+        from faker import Faker
+
         fake = Faker()
         if not hasattr(settings, 'TEAMVAULT_SECRET_KEY'):
             self.stderr.write(self.style.ERROR('TEAMVAULT_SECRET_KEY is not set in settings.'))

--- a/teamvault/apps/secrets/management/commands/create_fake_data.py
+++ b/teamvault/apps/secrets/management/commands/create_fake_data.py
@@ -1,0 +1,103 @@
+import random
+from datetime import timedelta
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from django.contrib.auth.models import User, Group
+from teamvault.apps.secrets.models import Secret, SecretRevision, SharedSecretData
+from faker import Faker
+from django.conf import settings
+from cryptography.fernet import Fernet
+import json
+from hashlib import sha256
+
+class Command(BaseCommand):
+    help = 'Create fake users and secrets'
+
+    def handle(self, *args, **kwargs):
+        fake = Faker()
+        if not hasattr(settings, 'TEAMVAULT_SECRET_KEY'):
+            self.stderr.write(self.style.ERROR('TEAMVAULT_SECRET_KEY is not set in settings.'))
+            return
+
+        try:
+            fernet = Fernet(settings.TEAMVAULT_SECRET_KEY)
+        except Exception as e:
+            self.stderr.write(self.style.ERROR(f'Invalid TEAMVAULT_SECRET_KEY: {e}'))
+            return
+
+        groups = []
+        for _ in range(5):
+            group_name = fake.unique.word().capitalize()
+            group, created = Group.objects.get_or_create(name=group_name)
+            groups.append(group)
+        self.stdout.write(self.style.SUCCESS(f'Created {len(groups)} groups.'))
+
+        # Create 50 fake users
+        users = []
+        for _ in range(50):
+            try:
+                username = fake.unique.user_name()
+                email = fake.unique.email()
+                password = fake.password(length=12)
+                user = User.objects.create_user(username=username, email=email, password=password)
+                # Optionally, assign user to random groups
+                if groups:
+                    user_groups = random.sample(groups, k=random.randint(0, len(groups)))
+                    user.groups.set(user_groups)
+                user.save()
+                users.append(user)
+            except Exception as e:
+                self.stderr.write(self.style.ERROR(f'Error creating user: {e}'))
+        self.stdout.write(self.style.SUCCESS('Created 50 fake users.'))
+
+        # Create secrets for each user
+        for user in users:
+            for _ in range(10):
+                try:
+                    secret_name = fake.unique.word().capitalize()
+                    description = fake.sentence(nb_words=10)
+                    url = fake.url()
+                    username_field = fake.user_name()
+                    # Create the Secret object
+                    secret = Secret.objects.create(
+                        name=secret_name,
+                        description=description,
+                        url=url,
+                        username=username_field,
+                        content_type=Secret.CONTENT_PASSWORD,
+                        created_by=user,
+                        status=Secret.STATUS_OK,
+                    )
+                    # Optionally, share the secret with random groups/users
+                    if groups and random.choice([True, False]):
+                        group = random.choice(groups)
+                        SharedSecretData.objects.create(
+                            group=group,
+                            secret=secret,
+                            grant_description='Shared via fake data script',
+                            granted_by=user,
+                            granted_until=timezone.now() + timedelta(days=30)
+                        )
+                    # Create a SecretRevision
+                    plaintext_password = fake.password(length=12)
+                    plaintext_data = {
+                        'password': plaintext_password
+                    }
+                    plaintext_data_json = json.dumps(plaintext_data)
+                    plaintext_data_sha256 = sha256(plaintext_data_json.encode('utf-8')).hexdigest()
+                    encrypted_data = fernet.encrypt(plaintext_data_json.encode('utf-8'))
+                    secret_revision = SecretRevision.objects.create(
+                        secret=secret,
+                        set_by=user,
+                        encrypted_data=encrypted_data,
+                        length=len(plaintext_password),
+                        plaintext_data_sha256=plaintext_data_sha256,
+                    )
+                    # Assign the current_revision
+                    secret.current_revision = secret_revision
+                    secret.last_changed = timezone.now()
+                    secret.last_read = timezone.now()
+                    secret.save()
+                except Exception as e:
+                    self.stderr.write(self.style.ERROR(f'Error creating secret for user {user.username}: {e}'))
+        self.stdout.write(self.style.SUCCESS('Created secrets and secret revisions for all users.'))

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.9'",
@@ -525,6 +524,37 @@ wheels = [
 ]
 
 [[package]]
+name = "faker"
+version = "35.2.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "python-dateutil", marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/3e/4050154492fda971f17039b5f2619b2dc09a9264d032881bb57d2d99bd63/faker-35.2.2.tar.gz", hash = "sha256:0a79ebe8f0ea803f7bd288d51e2d445b86035a2480e048daee1bffbd4d69b32b", size = 1874955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/18/f70c67c9d3a71f1749faa027dad3cd626c728df5682458091d73c69ed9a9/Faker-35.2.2-py3-none-any.whl", hash = "sha256:94216ce3d8affdc0a8fd0ea8219c184c346a1dcf07b03f193e52f3116186621e", size = 1917799 },
+]
+
+[[package]]
+name = "faker"
+version = "37.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9'",
+]
+dependencies = [
+    { name = "tzdata", marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/a6/b77f42021308ec8b134502343da882c0905d725a4d661c7adeaf7acaf515/faker-37.1.0.tar.gz", hash = "sha256:ad9dc66a3b84888b837ca729e85299a96b58fdaef0323ed0baace93c9614af06", size = 1875707 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/a1/8936bc8e79af80ca38288dd93ed44ed1f9d63beb25447a4c59e746e01f8d/faker-37.1.0-py3-none-any.whl", hash = "sha256:dc2f730be71cb770e9c715b13374d80dbcee879675121ab51f9683d262ae9a1c", size = 1918783 },
+]
+
+[[package]]
 name = "gunicorn"
 version = "21.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -641,6 +671,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
 name = "python-ldap"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -697,6 +739,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]
@@ -768,6 +819,8 @@ dev = [
     { name = "django-stubs" },
     { name = "djangorestframework-stubs", version = "3.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "djangorestframework-stubs", version = "3.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "faker", version = "35.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "faker", version = "37.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 
 [package.metadata]
@@ -795,6 +848,7 @@ requires-dist = [
 dev = [
     { name = "django-stubs", specifier = "~=5.1" },
     { name = "djangorestframework-stubs", specifier = "~=3.15" },
+    { name = "faker" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Creates 50 fake users with random usernames, emails, and passwords
- Assigns users to randomly generated groups
- Generates secrets for each user, encrypting passwords using Fernet
- Shares some secrets with random groups for testing
- Uses Faker for realistic test data
- Ensures TEAMVAULT_SECRET_KEY is set before execution

This command is useful for populating the database with test data.