### PR TITLE
Add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,61 @@
+export TEAMVAULT_CONFIG_FILE := "teamvault.cfg"
+
+# just run
+default: run
+
+# Check lint, formatting, types and tests
+qa: check-lint check-format types test
+
+# Run ruff linter
+check-lint:
+  uvx ruff check
+
+# Fix ruff linting issues
+fix-lint:
+  uvx ruff check --fix
+
+# Check ruff formatting
+check-format:
+  uvx ruff format --check
+
+# Reformat using ruff
+format:
+  uvx ruff format
+
+# Check types with ty
+types:
+  uvx ty check
+
+# Run tests (once we have them)
+test:
+  echo "Tests not implemented yet"
+
+# Bring up postgres
+db:
+  # prefixed with '-' so the recipe doesn't fail if the container's already up
+  -docker run --rm --detach --publish=5432:5432 --name teamvault-postgres -e POSTGRES_USER=teamvault -e POSTGRES_PASSWORD=teamvault postgres:latest
+
+# wait until Postgres answers before starting servers
+db_ready:
+  until pg_isready -h localhost -p 5432 -U teamvault; do sleep 0.2; done
+
+# Run webpack (bun)
+webpack:
+  bun run serve
+
+# Start DB and then teamvault
+teamvault: db db_ready
+  uv run teamvault run
+
+# Run teamvault and webpack together
+[parallel]
+run: webpack teamvault
+
+# Run our install steps
+install: db db_ready 
+  uv sync
+  -uv run teamvault setup
+  vim teamvault.cfg  # base_url = http://localhost:8000; session_cookie_secure = False; database config as needed
+  uv run teamvault upgrade
+  uv run teamvault plumbing createsuperuser
+


### PR DESCRIPTION
[Just](https://just.systems/) is a modern command runner. 
This justfile makes it easy to initialize and run teamvault. 
(And to run linters and tests, once we have them and the repo is ready.)

Example usage:
```
# Show available recipes
$ just -l
Available recipes:
    check-format # Check ruff formatting
    check-lint   # Run ruff linter
    db           # Bring up postgres
    db_ready     # wait until Postgres answers before starting servers
    default      # just run
    fix-lint     # Fix ruff linting issues
    format       # Reformat using ruff
    install      # Run our install steps
    qa           # Check lint, formatting, types and tests
    run          # Run teamvault and webpack together
    teamvault    # Start DB and then teamvault
    test         # Run tests (once we have them)
    types        # Check types with ty
    webpack      # Run webpack (bun)

$ just run
# same as `just`, run is the default recipe

```
