### PR TITLE
Run tests on PR

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
-
+        # based on django version in dependencies - minus 3.10 & 3.11 because of typing support
+        python-version: [ "3.12", "3.13", "3.14"]
 
     env:
       TEAMVAULT_CONFIG_FILE: ${{ github.workspace }}/teamvault.cfg


### PR DESCRIPTION
Uses GitHub Actions in order to run django tests on PR, a Python matrix to test on multiple python versions and caches where it fits the shoe. 