### PR TITLE
Lazy load bigger js libs

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ db_ready:
 
 # Run frontend dev server (bun + rspack)
 frontend:
-  bun run serve
+  bun --bun run serve
 
 # Start DB and then teamvault
 teamvault: db db_ready

--- a/rspack.dev.js
+++ b/rspack.dev.js
@@ -6,6 +6,12 @@ const path = require('path');
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'eval-cheap-module-source-map',
+  // @rspack/cli's `serve` auto-enables lazyCompilation for web targets when
+  // unset. Its runtime POSTs to a relative `_rspack/lazy/trigger`, which the
+  // browser resolves against the Django origin (localhost:8000), not the
+  // rspack dev server (localhost:3000), so dynamic imports never resolve.
+  // We could make this work, but it's not worth it.
+  lazyCompilation: false,
   output: {
     publicPath: 'http://localhost:3000/dist/',
   },

--- a/rspack.dev.js
+++ b/rspack.dev.js
@@ -11,7 +11,6 @@ module.exports = merge(common, {
   },
   devServer: {
     static: path.resolve('./teamvault/static/bundled/'),
-    hot: true,
     port: 3000,
     devMiddleware: {
       publicPath: '/dist/',
@@ -19,6 +18,15 @@ module.exports = merge(common, {
     headers: {
       'Access-Control-Allow-Origin': '*',
     },
+    // HMR / live-reload deliberately disabled. The dev server still
+    // rebuilds bundles on file change and serves them over HTTP; the
+    // browser just needs a manual refresh to pick them up. Keeps the
+    // build runnable under Bun, whose node:http upgrade-write path
+    // doesn't flush WS handshake bytes (rspack-dev-server's HMR
+    // channel relies on that).
+    client: false,
+    hot: false,
+    liveReload: false,
   },
   ignoreWarnings: [
     {

--- a/teamvault/apps/secrets/templates/secrets/share_content/share_list_modal.html
+++ b/teamvault/apps/secrets/templates/secrets/share_content/share_list_modal.html
@@ -81,6 +81,7 @@
                                     <label class="form-label"
                                            for="{{ form.granted_until.id_for_label }}">{% translate "Expires on" %}</label>
                                     <div class="input-group" id="{{ form.granted_until.id_for_label }}_picker"
+                                         data-td-picker
                                          data-td-target-input="nearest"
                                          data-td-target-toggle="nearest">
                                         <input type="text" name="{{ form.granted_until.name }}" class="form-control"
@@ -231,34 +232,6 @@
             })
         </script>
     {% endif %}
-    <script>
-        var tdOptions = {
-            display: {
-                buttons: {
-                    clear: true,
-                    close: true,
-                },
-                icons: {
-                    time: 'fa fa-clock',
-                    date: 'fa fa-calendar',
-                    up: 'fa fa-arrow-up',
-                    down: 'fa fa-arrow-down',
-                    previous: 'fa fa-chevron-left',
-                    next: 'fa fa-chevron-right',
-                    today: 'fa fa-calendar-check',
-                    clear: 'fa fa-trash',
-                    close: 'fa fa-times-circle'
-                }
-            },
-            localization: {
-                format: 'yyyy-MM-dd HH:mm'
-            }
-        }
-        var td_picker = new window.TempusDominus(
-            document.getElementById('{{ form.granted_until.id_for_label }}_picker'),
-            tdOptions
-        )
-    </script>
 
     {% if show_object %}
         <script>

--- a/teamvault/static/js/entries/base.js
+++ b/teamvault/static/js/entries/base.js
@@ -6,7 +6,6 @@ import '../../scss/base.scss'
 import * as bootstrap from 'bootstrap'
 import $ from 'jquery'
 import {createPopper} from '@popperjs/core'
-import {TempusDominus} from '@eonasdan/tempus-dominus'
 import TomSelect from 'tom-select';
 
 // Modules
@@ -25,7 +24,6 @@ window.htmx = require('htmx.org')
 window.$ = $
 window.jQuery = $
 window.Popper = {createPopper}
-window.TempusDominus = TempusDominus
 window.TomSelect = TomSelect
 
 // Select2 initialization (attaches to $.fn, sets defaults, patches backspace)

--- a/teamvault/static/js/entries/secret-detail.js
+++ b/teamvault/static/js/entries/secret-detail.js
@@ -3,7 +3,12 @@ import {setUpPasswordClipboard, setUpOtpClipboard, setUpAdditionalClipboards} fr
 import {initOtp} from '../modules/secret-otp';
 import {init as initPasswordDetail} from '../modules/secret-detail-password';
 import {init as initCCDetail} from '../modules/secret-detail-cc';
+import {initTempusDominus} from '../modules/tempus-dominus-init';
 import * as bootstrap from 'bootstrap';
+
+// Kick off the tempus-dominus chunk download immediately and register
+// listeners that initialize the date picker once the share modal swaps in.
+initTempusDominus();
 
 document.addEventListener('DOMContentLoaded', () => {
   const config = document.getElementById('secret-detail-config');

--- a/teamvault/static/js/modules/password-form.js
+++ b/teamvault/static/js/modules/password-form.js
@@ -29,13 +29,17 @@ export function init(config) {
     let color = 'text-muted';
     if (passwordField.value) {
       const zxcvbn = await zxcvbnReady;
-      score = zxcvbn(passwordField.value.toString()).score + 1;
-      if (score <= 2) {
-        color = 'text-danger-bright';
-      } else if (score === 5) {
-        color = 'text-success-bright';
-      } else {
-        color = 'text-warning-bright';
+      // Re-check after the await: the user may have cleared the field
+      // while the zxcvbn chunk was still downloading.
+      if (passwordField.value) {
+        score = zxcvbn(passwordField.value.toString()).score + 1;
+        if (score <= 2) {
+          color = 'text-danger-bright';
+        } else if (score === 5) {
+          color = 'text-success-bright';
+        } else {
+          color = 'text-warning-bright';
+        }
       }
     }
     const filledStar = `<i class='fas fa-star ${color}'></i>`;

--- a/teamvault/static/js/modules/password-form.js
+++ b/teamvault/static/js/modules/password-form.js
@@ -1,7 +1,12 @@
 import * as bootstrap from 'bootstrap';
-import {initZxcvbn} from '../zxcvbn.ts';
 
-const zxcvbn = initZxcvbn();
+// zxcvbn dictionaries (~1.6 MB) and the jsqr QR scanner (~250 KB) start
+// downloading the moment this module evaluates — the secret-addedit
+// entry imports this file, so the fetch begins as soon as the page's
+// JS runs, in parallel with everything else. Use sites await the saved
+// promise so first interaction never waits on network.
+const zxcvbnReady = import(/* webpackChunkName: "zxcvbn" */ '../zxcvbn.ts').then(m => m.initZxcvbn());
+const jsqrReady = import(/* webpackChunkName: "jsqr" */ 'jsqr').then(m => m.default);
 
 export function init(config) {
   const generatePasswordUrl = config.dataset.generatePasswordUrl;
@@ -19,16 +24,19 @@ export function init(config) {
 
   passwordField.generated = false;
 
-  function ratePassword() {
-    let score = zxcvbn(passwordField.value.toString()).score + 1;
-    let color = 'text-warning-bright';
-    if (!passwordField.value) {
-      color = 'text-muted';
-      score = 0;
-    } else if (score <= 2) {
-      color = 'text-danger-bright';
-    } else if (score === 5) {
-      color = 'text-success-bright';
+  async function ratePassword() {
+    let score = 0;
+    let color = 'text-muted';
+    if (passwordField.value) {
+      const zxcvbn = await zxcvbnReady;
+      score = zxcvbn(passwordField.value.toString()).score + 1;
+      if (score <= 2) {
+        color = 'text-danger-bright';
+      } else if (score === 5) {
+        color = 'text-success-bright';
+      } else {
+        color = 'text-warning-bright';
+      }
     }
     const filledStar = `<i class='fas fa-star ${color}'></i>`;
     const hollowStar = `<i class='far fa-star ${color}'></i>`;
@@ -88,7 +96,7 @@ export function init(config) {
 
   ratePassword();
 
-  otpField.addEventListener('change', () => {
+  otpField.addEventListener('change', async () => {
     if (otpField.type !== 'file') {
       return;
     }
@@ -96,7 +104,7 @@ export function init(config) {
     if (!file) {
       return;
     }
-    const qrScanner = require('jsqr');
+    const qrScanner = await jsqrReady;
     const reader = new FileReader();
     reader.onload = function (event) {
       const img = new Image();

--- a/teamvault/static/js/modules/password-form.js
+++ b/teamvault/static/js/modules/password-form.js
@@ -82,7 +82,24 @@ export function init(config) {
     }
   });
 
-  document.addEventListener('submit', () => {
+  let qrDecodePending = false;
+
+  document.addEventListener('submit', e => {
+    // Only intervene for submits of the form that owns the OTP field.
+    // Don't preventDefault on unrelated forms (e.g. nav search).
+    if (!e.target.contains(otpField)) {
+      return;
+    }
+    if (qrDecodePending) {
+      // QR scanner chunk or decode still in flight; otpField.value is
+      // the file-input pseudo-path right now, not a usable OTP secret.
+      e.preventDefault();
+      window.notyf.error('Still decoding QR code, please try again.');
+      return;
+    }
+    if (otpField.type !== 'text') {
+      return;
+    }
     if (otpField.value && !otpKeyData.value) {
       let data = otpField.value;
       if (!data.includes('?secret=')) {
@@ -108,33 +125,46 @@ export function init(config) {
     if (!file) {
       return;
     }
-    const qrScanner = await jsqrReady;
-    const reader = new FileReader();
-    reader.onload = function (event) {
-      const img = new Image();
-      img.onload = function () {
-        const canvas = document.getElementById('canvas');
-        const ctx = canvas.getContext('2d');
-        canvas.width = img.width;
-        canvas.height = img.height;
-        ctx.fillStyle = 'rgb(255, 255, 255)';
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-        try {
-          const code = qrScanner(imageData.data, imageData.width, imageData.height);
-          keyInputQr();
-          let data = new URL(code.data.toString());
-          otpKeyData.value = data;
-          otpField.value = data.searchParams.get('secret');
-        } catch (e) {
-          keyInputText();
-          window.notyf.error('Error. No QR code found. Please try again.');
-        }
-      };
-      img.src = event.target.result;
-    };
-    reader.readAsDataURL(file);
+    qrDecodePending = true;
+    try {
+      const qrScanner = await jsqrReady;
+      // Wrap the FileReader/Image chain in a promise so the
+      // qrDecodePending flag covers the entire async pipeline, not
+      // just the jsqr chunk download.
+      await new Promise(resolve => {
+        const reader = new FileReader();
+        reader.onerror = () => resolve();
+        reader.onload = function (event) {
+          const img = new Image();
+          img.onerror = () => resolve();
+          img.onload = function () {
+            const canvas = document.getElementById('canvas');
+            const ctx = canvas.getContext('2d');
+            canvas.width = img.width;
+            canvas.height = img.height;
+            ctx.fillStyle = 'rgb(255, 255, 255)';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+            const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+            try {
+              const code = qrScanner(imageData.data, imageData.width, imageData.height);
+              keyInputQr();
+              let data = new URL(code.data.toString());
+              otpKeyData.value = data;
+              otpField.value = data.searchParams.get('secret');
+            } catch (e) {
+              keyInputText();
+              window.notyf.error('Error. No QR code found. Please try again.');
+            }
+            resolve();
+          };
+          img.src = event.target.result;
+        };
+        reader.readAsDataURL(file);
+      });
+    } finally {
+      qrDecodePending = false;
+    }
   });
 
   passwordField.addEventListener('keyup', () => {

--- a/teamvault/static/js/modules/tempus-dominus-init.js
+++ b/teamvault/static/js/modules/tempus-dominus-init.js
@@ -49,6 +49,10 @@ async function initIn(root) {
   if (!els.length) return;
   const TempusDominus = await tdReady;
   for (const el of els) {
+    // Re-check after the await: htmx:afterSwap and shown.bs.modal can
+    // both fire for the same modal content while tdReady is pending,
+    // so a previous initIn call may have already initialized this el.
+    if (el.dataset.tdInitialized === 'true') continue;
     new TempusDominus(el, tdOptions);
     el.dataset.tdInitialized = 'true';
   }

--- a/teamvault/static/js/modules/tempus-dominus-init.js
+++ b/teamvault/static/js/modules/tempus-dominus-init.js
@@ -1,0 +1,61 @@
+// Lazy-loads @eonasdan/tempus-dominus (~190 KB) on pages that may
+// render a date picker. Currently only secret-detail uses this — the
+// share modal's "expires on" picker. Imported by entries/secret-detail
+// so the chunk download fires the moment the page's JS evaluates, in
+// parallel with the htmx GET that swaps the share modal content in.
+//
+// Templates mark the picker root with `data-td-picker`; this module
+// finds those roots after they appear in the DOM (initial load, htmx
+// swaps, modal show) and initializes the picker exactly once per
+// element.
+//
+// To add a new date picker:
+//   1. Render an element with `data-td-picker` (typically the
+//      tempus-dominus root div).
+//   2. Make sure the element appears via one of the supported insertion
+//      paths: present at DOMContentLoaded, swapped in by htmx, or shown
+//      inside a Bootstrap modal. Other insertion paths require an
+//      explicit `initIn(root)` call.
+//   3. If a new entry needs date pickers, import + call
+//      `initTempusDominus()` from that entry as well.
+
+const tdReady = import(/* webpackChunkName: "tempus-dominus" */ '@eonasdan/tempus-dominus').then(m => m.TempusDominus);
+
+const tdOptions = {
+  display: {
+    buttons: {
+      clear: true,
+      close: true,
+    },
+    icons: {
+      time: 'fa fa-clock',
+      date: 'fa fa-calendar',
+      up: 'fa fa-arrow-up',
+      down: 'fa fa-arrow-down',
+      previous: 'fa fa-chevron-left',
+      next: 'fa fa-chevron-right',
+      today: 'fa fa-calendar-check',
+      clear: 'fa fa-trash',
+      close: 'fa fa-times-circle',
+    },
+  },
+  localization: {
+    format: 'yyyy-MM-dd HH:mm',
+  },
+};
+
+async function initIn(root) {
+  const els = root.querySelectorAll('[data-td-picker]:not([data-td-initialized])');
+  if (!els.length) return;
+  const TempusDominus = await tdReady;
+  for (const el of els) {
+    new TempusDominus(el, tdOptions);
+    el.dataset.tdInitialized = 'true';
+  }
+}
+
+export function initTempusDominus() {
+  document.addEventListener('DOMContentLoaded', () => initIn(document));
+  document.body.addEventListener('htmx:afterSwap', e => initIn(e.target));
+  document.body.addEventListener('shown.bs.modal', e => initIn(e.target));
+}


### PR DESCRIPTION
Split heavy libs into their own chunks and kick off the download in the
background the moment the entry that needs them runs, so first user
interaction never waits on network. Init happens when both the chunk is
ready and the relevant element/event is present.

- zxcvbn (~1.6 MB) and jsqr (~250 KB): import() hoisted to module-init
  in password-form.js. Promises fire when the secret-addedit entry
  evaluates; ratePassword and the OTP-file change handler just await
  the saved promises. ratePassword skips the await when the field is
  empty so the score-0 case stays sync.
- tempus-dominus (~190 KB): new tempus-dominus-init module fires the
  import on module evaluation and registers DOMContentLoaded /
  htmx:afterSwap / shown.bs.modal listeners that initialize the picker
  on any [data-td-picker] element. Imported only by the secret-detail
  entry, so other pages don't fetch the chunk.
- share_list_modal.html: dropped the inline tdOptions / new
  window.TempusDominus(...) block, marked the picker root with
  data-td-picker. Options live in the init module now.

Initial download per page:
  base          946.7 KB ->  868.2 KB  (-78 KB)
  secret-detail 302.7 KB ->  307.0 KB  (~unchanged; +runtime)
  secret-addedit 2,084 KB ->  294.4 KB (-1,790 KB, -86%)
