### PR TITLE
Gunicorn Tuning 

### DIFF
--- a/teamvault/apps/settings/config.py
+++ b/teamvault/apps/settings/config.py
@@ -2,7 +2,7 @@ import pathlib
 from base64 import b64decode, b64encode
 from configparser import ConfigParser
 from gettext import gettext as _
-from os import environ, umask
+from os import cpu_count, environ, umask
 from secrets import choice
 from string import ascii_letters, digits, punctuation
 from urllib.parse import urlparse
@@ -181,6 +181,18 @@ def configure_google_auth(config, settings):
 
     # LDAP compatibility settings
     # When LDAP is enabled, social auth user creation is handled via entry_uuid linking.
+
+
+def configure_gunicorn(config):
+    # cpu_count() reflects host CPUs, not cgroup quota. In containers with
+    # restricted CPU, set [gunicorn] workers explicitly.
+    default_workers = (cpu_count() or 1) * 2 + 1
+    return {
+        'workers': int(get_from_config(config, 'gunicorn', 'workers', str(default_workers))),
+        'timeout': int(get_from_config(config, 'gunicorn', 'timeout', '30')),
+        'max_requests': int(get_from_config(config, 'gunicorn', 'max_requests', '1000')),
+        'max_requests_jitter': int(get_from_config(config, 'gunicorn', 'max_requests_jitter', '200')),
+    }
 
 
 def configure_huey(config):
@@ -474,6 +486,18 @@ salt = {hashid_salt}
 #oauth2_key = 123456789.apps.googleusercontent.com
 #oauth2_secret = ******************
 #use_avatars = True
+
+#[gunicorn]
+## Number of worker processes. Defaults to (2 * CPU cores) + 1.
+## In containers with restricted CPU, set this explicitly.
+## cpu_count() reflects host CPUs, not the cgroup quota.
+#workers = 5
+## Worker timeout in seconds. Workers idle longer than this are killed.
+#timeout = 30
+## Restart each worker after this many requests (preventive recycling).
+#max_requests = 1000
+## Random offset added per worker so they don't all recycle at once.
+#max_requests_jitter = 200
 
 #[tasks]
 #scheduler_frequency = daily  # or hourly, minutely

--- a/teamvault/cli.py
+++ b/teamvault/cli.py
@@ -4,14 +4,18 @@ import sys
 from argparse import REMAINDER, ArgumentParser
 from hashlib import sha1
 from importlib import metadata
-from os import environ
+from os import environ, execvp
 from shutil import rmtree
-from subprocess import Popen
 
 import django
 from django.core.management import execute_from_command_line, get_commands
 
-from teamvault.apps.settings.config import UnconfiguredSettingsError, create_default_config
+from teamvault.apps.settings.config import (
+    UnconfiguredSettingsError,
+    configure_gunicorn,
+    create_default_config,
+    get_config,
+)
 
 
 def build_parser():
@@ -48,6 +52,11 @@ def build_parser():
     # teamvault run
     parser_run = subparsers.add_parser('run')
     parser_run.add_argument('--bind', nargs='?', help='define bind, default is 127.0.0.1:8000')
+    parser_run.add_argument(
+        'gunicorn_args',
+        nargs=REMAINDER,
+        help='extra arguments passed verbatim to gunicorn (use -- as separator, e.g. teamvault run -- --threads 4)',
+    )
     parser_run.set_defaults(func=run)
 
     # teamvault run_huey
@@ -87,16 +96,34 @@ def plumbing(pargs):
 
 def run(pargs):
     execute_from_command_line(['', 'check'])
-    cmd = 'gunicorn --preload teamvault.wsgi:application'
+    gunicorn_settings = configure_gunicorn(get_config())
+
+    argv = [
+        'gunicorn',
+        '--preload',
+        '--workers',
+        str(gunicorn_settings['workers']),
+        '--timeout',
+        str(gunicorn_settings['timeout']),
+        '--max-requests',
+        str(gunicorn_settings['max_requests']),
+        '--max-requests-jitter',
+        str(gunicorn_settings['max_requests_jitter']),
+    ]
     if pargs.bind:
-        cmd += ' -b ' + pargs.bind
+        argv.extend(['-b', pargs.bind])
+
+    extra = list(pargs.gunicorn_args or [])
+    if extra and extra[0] == '--':
+        extra = extra[1:]
+    argv.extend(extra)
+
+    argv.append('teamvault.wsgi:application')
 
     print('Now open http://localhost:8000')
-    gunicorn = Popen(
-        cmd,
-        shell=True,
-    )
-    gunicorn.communicate()
+    # Replace this process with gunicorn so signals (SIGTERM from systemd,
+    # Docker, etc.) reach gunicorn directly and graceful shutdown works.
+    execvp('gunicorn', argv)
 
 
 def run_huey(_pargs):


### PR DESCRIPTION
So far, we've been pretty negligent about how we actually start teamvault/gunicorn.

# 1. Gunicorn Tuning
The default worker count is a whole *1*.
Especially when running this together with something like
https://github.com/trehn/bundlewrap-teamvault, the API gets bombarded with requests.
When a user logs in and teamvault waits on LDAP or waits for the DB (like in the auditlog queries),
this then results in quite a slowdown for all API users.
With this PR, the default worker count corresponds to (CPU_COUNT * 2) + 1, as the gunicorn docs recommend.

# 2. Change from Popen to execvp
The change from Popen to execvp results in the actual process to now
being named "gunicorn" instead of "teamvault". This might break some
monitoring initally, but is ultimately the right call if we want gunicorns
auto-lifecycle stuff to work properly.