### PR TITLE
add basic favicon

### DIFF
--- a/teamvault/static/img/favicon.svg
+++ b/teamvault/static/img/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M32 4 L8 12 V32 C8 47 18 57 32 62 C46 57 56 47 56 32 V12 Z" fill="#2f2d35" stroke="#f8592c" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 20 a7 7 0 0 0 -4.5 12.3 L25 47 H39 L36.5 32.3 A7 7 0 0 0 32 20 Z" fill="#f8592c"/>
+</svg>

--- a/teamvault/templates/base.html
+++ b/teamvault/templates/base.html
@@ -10,7 +10,7 @@
     <title>{% trans "TeamVault" %} &middot; {% block title %}{% endblock %}</title>
 
     <link href="{% url 'opensearch' %}" type="application/opensearchdescription+xml" title="TeamVault" rel="search">
-    <link rel="icon" type="image/x-icon" href="{% static 'rest_framework/docs/img/favicon.ico' %}">
+    <link rel="icon" type="image/svg+xml" href="{% static 'img/favicon.svg' %}">
 
     {% render_bundle 'base' attrs='crossorigin="anonymous"' %}
 


### PR DESCRIPTION
an update of DRF now changes the favicon path which breaks the new Playwright builds. This is just a low-effort svg, but it does the job.