### PR TITLE
Create revision history entries for secret-changes via API

### DIFF
--- a/teamvault/apps/secrets/api/views.py
+++ b/teamvault/apps/secrets/api/views.py
@@ -45,10 +45,14 @@ class SecretDetail(generics.RetrieveUpdateDestroyAPIView):
         return obj
 
     def perform_update(self, serializer):
-        instance = serializer.save()
+        instance: Secret = serializer.save()
         if hasattr(instance, '_data'):
             RevisionService.save_payload(secret=instance, actor=self.request.user, payload=instance._data)
             del instance._data
+        # Only metadata changed
+        elif instance.current_revision:
+            current_data = instance.current_revision.peek_data(self.request.user)
+            RevisionService.save_payload(secret=instance, actor=self.request.user, payload=current_data)
 
 
 class SecretList(generics.ListCreateAPIView):

--- a/teamvault/apps/secrets/api/views.py
+++ b/teamvault/apps/secrets/api/views.py
@@ -1,3 +1,4 @@
+import base64
 from base64 import b64encode
 
 from django.conf import settings
@@ -52,6 +53,9 @@ class SecretDetail(generics.RetrieveUpdateDestroyAPIView):
         # Only metadata changed
         elif instance.current_revision:
             current_data = instance.current_revision.peek_data(self.request.user)
+            if instance.content_type == ContentType.FILE and isinstance(current_data, (bytes, bytearray)):
+                # Keep current data on metadata-only edit
+                current_data = {'file_content': base64.b64encode(current_data).decode()}
             RevisionService.save_payload(secret=instance, actor=self.request.user, payload=current_data)
 
 

--- a/teamvault/apps/secrets/api/views.py
+++ b/teamvault/apps/secrets/api/views.py
@@ -1,4 +1,3 @@
-import base64
 from base64 import b64encode
 
 from django.conf import settings
@@ -52,11 +51,7 @@ class SecretDetail(generics.RetrieveUpdateDestroyAPIView):
             del instance._data
         # Only metadata changed
         elif instance.current_revision:
-            current_data = instance.current_revision.peek_data(self.request.user)
-            if instance.content_type == ContentType.FILE and isinstance(current_data, (bytes, bytearray)):
-                # Keep current data on metadata-only edit
-                current_data = {'file_content': base64.b64encode(current_data).decode()}
-            RevisionService.save_payload(secret=instance, actor=self.request.user, payload=current_data)
+            RevisionService.save_payload(secret=instance, actor=self.request.user, payload=None)
 
 
 class SecretList(generics.ListCreateAPIView):

--- a/teamvault/apps/secrets/services/revision.py
+++ b/teamvault/apps/secrets/services/revision.py
@@ -11,6 +11,7 @@ from django.db import transaction
 from django.urls import reverse
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
+
 from teamvault.apps.audit.auditlog import log
 from teamvault.apps.audit.models import AuditLogCategoryChoices
 from teamvault.apps.secrets.enums import AccessPolicy, ContentType, SecretStatus
@@ -26,7 +27,7 @@ from teamvault.apps.secrets.utils import META_FIELDS, apply_snapshot_to_secret, 
 @dataclass
 class HistoryEntry:
     ts: datetime
-    kind: Literal['payload', 'meta', 'restore']
+    kind: Literal['payload', 'meta', 'payload_and_meta', 'restore']
     user: str
     name: str
     changes: list[dict[str, str]]
@@ -260,7 +261,14 @@ class RevisionService:
             meta_changes = cls._get_meta_diff(ch, parent)
 
             # Determine kind
-            kind = 'restore' if ch.restored_from_id else ('payload' if payload_changes else 'meta')
+            if ch.restored_from_id:
+                kind = 'restore'
+            elif payload_changes and meta_changes:
+                kind = 'payload_and_meta'
+            elif payload_changes:
+                kind = 'payload'
+            elif meta_changes:
+                kind = 'meta'
 
             # Merge changes: payload first for readability
             merged = []

--- a/teamvault/apps/secrets/services/revision.py
+++ b/teamvault/apps/secrets/services/revision.py
@@ -11,7 +11,6 @@ from django.db import transaction
 from django.urls import reverse
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
-
 from teamvault.apps.audit.auditlog import log
 from teamvault.apps.audit.models import AuditLogCategoryChoices
 from teamvault.apps.secrets.enums import AccessPolicy, ContentType, SecretStatus

--- a/teamvault/apps/secrets/services/revision.py
+++ b/teamvault/apps/secrets/services/revision.py
@@ -11,6 +11,7 @@ from django.db import transaction
 from django.urls import reverse
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
+
 from teamvault.apps.audit.auditlog import log
 from teamvault.apps.audit.models import AuditLogCategoryChoices
 from teamvault.apps.secrets.enums import AccessPolicy, ContentType, SecretStatus
@@ -61,7 +62,7 @@ class RevisionService:
         *,
         secret: Secret,
         actor,  # settings.AUTH_USER_MODEL
-        payload: dict[str, Any],
+        payload: dict[str, Any] | None = None,
         skip_acl: bool = False,
     ) -> SecretRevision:
         """Create or reuse a payload revision, set it current, and record
@@ -71,10 +72,14 @@ class RevisionService:
             raise PermissionDenied('User has no write access to secret payload')
 
         # 1. Build (or fetch) the revision representing _payload_
-        revision = cls._build_revision(secret=secret, actor=actor, payload=payload)
-        payload_changed = revision.plaintext_data_sha256 != (
-            secret.current_revision.plaintext_data_sha256 if secret.current_revision_id else None
-        )
+        if payload is not None:
+            revision = cls._build_revision(secret=secret, actor=actor, payload=payload)
+            payload_changed = revision.plaintext_data_sha256 != (
+                secret.current_revision.plaintext_data_sha256 if secret.current_revision_id else None
+            )
+        else:
+            revision = secret.current_revision
+            payload_changed = False
 
         previous_change = SecretChange.objects.filter(secret=secret).order_by('-created').first()
         incoming_snapshot = copy_meta_from_secret(secret)

--- a/teamvault/apps/secrets/services/revision.py
+++ b/teamvault/apps/secrets/services/revision.py
@@ -92,7 +92,7 @@ class RevisionService:
         secret.current_revision = revision
         secret.last_changed = now()
         secret.last_read = now()
-        # Only clear NEEDS_CHANGING when payload actually changes
+        # 3. Only clear NEEDS_CHANGING when payload actually changes
         if payload_changed and secret.status == SecretStatus.NEEDS_CHANGING:
             secret.status = SecretStatus.OK
         secret.save(update_fields=['current_revision', 'last_changed', 'last_read', 'status'])
@@ -130,7 +130,6 @@ class RevisionService:
 
         return revision
 
-    @classmethod
     @classmethod
     @transaction.atomic
     def restore_to_change(
@@ -458,8 +457,3 @@ class RevisionService:
                         })
 
             return diffs or [{'label': 'Payload', 'old': '∅', 'new': 'Changed'}]
-
-    @staticmethod
-    def _is_current_payload(revision: SecretRevision, secret: Secret) -> bool:
-        """Check if this revision is the current payload."""
-        return revision.id == secret.current_revision_id

--- a/teamvault/apps/secrets/templates/secrets/secret_revisions.html
+++ b/teamvault/apps/secrets/templates/secrets/secret_revisions.html
@@ -106,7 +106,7 @@
                                   </form>
                               {% endif %}
                               {% if r.current %}
-                                  {% if r.kind == "payload" %}
+                                  {% if r.kind == "payload" or r.kind == "payload_and_meta" %}
                                     <span data-bs-toggle="tooltip"
                                           title="{% trans 'Current secret revision' %}">
                                       <i class="fa fa-star text-warning"></i>

--- a/teamvault/apps/secrets/templates/secrets/secret_revisions.html
+++ b/teamvault/apps/secrets/templates/secrets/secret_revisions.html
@@ -11,14 +11,15 @@
         </h2>
         <div class="card">
             <div class="card-body table-responsive">
-                <table class="table table-hover">
+                <table class="table table-hover table-layout-fixed">
                     <thead>
                         <tr>
-                            <th>{% trans "Date" %}</th>
-                            <th>{% trans "Changed by" %}</th>
-                            <th>{% trans "Name" %}</th>
-                            <th>{% trans "Details" %}</th>
-                            <th>{% trans "View" %}</th>
+                            <th id="date">{% trans "Date" %}</th>
+                            <th id="change-type" aria-label="Change type"></th>
+                            <th id="changed-by">{% trans "Changed by" %}</th>
+                            <th id="name">{% trans "Name" %}</th>
+                            <th id="details">{% trans "Details" %}</th>
+                            <th id="view">{% trans "View" %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -32,31 +33,36 @@
                             </span>
                           </td>
                           <td>
-                            {% if r.kind == "payload" %}
-                              <span>
+                            <div class="d-flex align-items-center">
+                              {% if r.kind == "payload" %}
+                                <span>
+                                  <i class="fa fa-key text-primary ms-1" data-bs-toggle="tooltip"
+                                   title="{% trans 'Secret value changed' %}"></i>
+                                </span>
+                                <span class="revision-icon-placeholder"></span>
+                              {% elif r.kind == "restore" %}
+                                <span>
+                                  <i class="fa fa-undo text-danger me-1" data-bs-toggle="tooltip"
+                                   title="{% trans 'Secret was restored to this version' %}"></i>
+                                </span>
+                                <span class="revision-icon-placeholder"></span>
+                              {% elif r.kind == "meta" %}
+                                <span>
+                                  <i class="fa fa-pencil text-muted ms-1" data-bs-toggle="tooltip"
+                                   title="{% trans 'Metadata changed' %}"></i>
+                                </span>
+                                <span class="revision-icon-placeholder"></span>
+                              {% elif r.kind == "payload_and_meta" %}
                                 <i class="fa fa-key text-primary ms-1" data-bs-toggle="tooltip"
                                  title="{% trans 'Secret value changed' %}"></i>
-                              </span>
-                              <span class="revision-icon-placeholder"></span>
-                            {% elif r.kind == "restore" %}
-                              <span>
-                                <i class="fa fa-undo text-danger me-1" data-bs-toggle="tooltip"
-                                 title="{% trans 'Secret was restored to this version' %}"></i>
-                              </span>
-                              <span class="revision-icon-placeholder"></span>
-                            {% elif r.kind == "meta" %}
-                              <span>
                                 <i class="fa fa-pencil text-muted ms-1" data-bs-toggle="tooltip"
                                  title="{% trans 'Metadata changed' %}"></i>
-                              </span>
-                              <span class="revision-icon-placeholder"></span>
-                            {% elif r.kind == "payload_and_meta" %}
-                              <i class="fa fa-key text-primary ms-1" data-bs-toggle="tooltip"
-                               title="{% trans 'Secret value changed' %}"></i>
-                              <i class="fa fa-pencil text-muted ms-1" data-bs-toggle="tooltip"
-                               title="{% trans 'Metadata changed' %}"></i>
-                            {% endif %}
-                            {{ r.user }}
+                              {% endif %}
+                            </div>
+                          </td>
+
+                          <td>
+                            <span class="d-block text-truncate" data-bs-toggle="tooltip" title="{{ r.user }}">{{ r.user }}</span>
                           </td>
 
                           <td>

--- a/teamvault/apps/secrets/templates/secrets/secret_revisions.html
+++ b/teamvault/apps/secrets/templates/secrets/secret_revisions.html
@@ -25,7 +25,7 @@
                       {% for r in rows %}
                         <tr>
                           <td>
-                            <span data-bs-toggle="tooltip" 
+                            <span data-bs-toggle="tooltip"
                                   data-bs-placement="right"
                                   title="{{ r.ts|date:'Y-m-d H:i:s' }}">
                               {{ r.ts|naturaltime }}
@@ -33,16 +33,28 @@
                           </td>
                           <td>
                             {% if r.kind == "payload" %}
-                              <i class="fa fa-key text-primary ms-1" data-bs-toggle="tooltip"
+                              <span>
+                                <i class="fa fa-key text-primary ms-1" data-bs-toggle="tooltip"
                                  title="{% trans 'Secret value changed' %}"></i>
+                              </span>
+                              <span class="revision-icon-placeholder"></span>
                             {% elif r.kind == "restore" %}
-                              <i class="fa fa-undo text-danger me-1"
-                                 data-bs-toggle="tooltip"
+                              <span>
+                                <i class="fa fa-undo text-danger me-1" data-bs-toggle="tooltip"
                                  title="{% trans 'Secret was restored to this version' %}"></i>
-                            {% else %}
-                              <i class="fa fa-pencil text-muted ms-1" data-bs-toggle="tooltip"
+                              </span>
+                              <span class="revision-icon-placeholder"></span>
+                            {% elif r.kind == "meta" %}
+                              <span>
+                                <i class="fa fa-pencil text-muted ms-1" data-bs-toggle="tooltip"
                                  title="{% trans 'Metadata changed' %}"></i>
-
+                              </span>
+                              <span class="revision-icon-placeholder"></span>
+                            {% elif r.kind == "payload_and_meta" %}
+                              <i class="fa fa-key text-primary ms-1" data-bs-toggle="tooltip"
+                               title="{% trans 'Secret value changed' %}"></i>
+                              <i class="fa fa-pencil text-muted ms-1" data-bs-toggle="tooltip"
+                               title="{% trans 'Metadata changed' %}"></i>
                             {% endif %}
                             {{ r.user }}
                           </td>

--- a/teamvault/apps/secrets/views.py
+++ b/teamvault/apps/secrets/views.py
@@ -1,4 +1,3 @@
-import base64
 import contextlib
 from copy import copy
 from urllib.parse import quote, urlencode
@@ -168,18 +167,13 @@ class SecretEdit(UpdateView):
         secret.save()
         plaintext_data = serialize_add_edit_data(form.cleaned_data, secret)
 
-        if not plaintext_data:  # Only metadata changed
-            # Re-use the existing encrypted data to create a new revision
+        # Only metadata changed
+        if not plaintext_data:
             if form.changed_data and secret.current_revision:
-                # Avoid logging a read for internal book-keeping
-                current_data = secret.current_revision.peek_data(self.request.user)
-                if secret.content_type == ContentType.FILE and isinstance(current_data, (bytes, bytearray)):
-                    # Keep current data on metadata-only edit
-                    current_data = {'file_content': base64.b64encode(current_data).decode()}
                 RevisionService.save_payload(
                     secret=secret,
                     actor=self.request.user,
-                    payload=current_data,
+                    payload=None,
                 )
         else:
             RevisionService.save_payload(

--- a/teamvault/static/scss/secrets.scss
+++ b/teamvault/static/scss/secrets.scss
@@ -172,3 +172,8 @@ $max_progress: 30s;
 [data-bs-theme="light"] #id_pwgen:hover {
   background: #ddd;
 }
+
+.revision-icon-placeholder {
+  display: inline-block;
+  width: 1.25em;
+}

--- a/teamvault/static/scss/secrets.scss
+++ b/teamvault/static/scss/secrets.scss
@@ -177,3 +177,26 @@ $max_progress: 30s;
   display: inline-block;
   width: 1.25em;
 }
+
+.table-layout-fixed {
+    table-layout: fixed;
+
+    #date {
+      width: 12%;
+    }
+    #change-type {
+      width: 4%;
+    }
+    #changed-by {
+      width: 15%;
+    }
+    #name {
+      width: 15%;
+    }
+    #details {
+      width: 44%;
+    }
+    #view {
+      width: 10%;
+    }
+}

--- a/teamvault/static/scss/secrets.scss
+++ b/teamvault/static/scss/secrets.scss
@@ -179,24 +179,29 @@ $max_progress: 30s;
 }
 
 .table-layout-fixed {
-    table-layout: fixed;
+  table-layout: fixed;
 
-    #date {
-      width: 12%;
-    }
-    #change-type {
-      width: 4%;
-    }
-    #changed-by {
-      width: 15%;
-    }
-    #name {
-      width: 15%;
-    }
-    #details {
-      width: 44%;
-    }
-    #view {
-      width: 10%;
-    }
+  #date {
+    width: 12%;
+  }
+
+  #change-type {
+    width: 4%;
+  }
+
+  #changed-by {
+    width: 15%;
+  }
+
+  #name {
+    width: 15%;
+  }
+
+  #details {
+    width: 44%;
+  }
+
+  #view {
+    width: 10%;
+  }
 }


### PR DESCRIPTION
### Feature:
Changes to a secret via the API now create an entry in the revision history of this secret. Before, entries were only created if changes were made in the browser.


### Styling the revision history:
- Separate icons for the change-type in their own column
- Show both icons, if changes include secret_data AND metadata
- Add fixed table-layout with percentage column widths
- Truncate long usernames with tooltip showing the full name