### PR TITLE
Fix Google-Login after social-auth-app-django upgrade to version 6.0.0

### DIFF
--- a/teamvault/apps/accounts/templates/accounts/login.html
+++ b/teamvault/apps/accounts/templates/accounts/login.html
@@ -5,37 +5,42 @@
 {% block title %}{% trans "Login" %}{% endblock %}
 {% block super_content %}
     <div class="d-flex justify-content-center align-items-center vh-100">
-        <form id="loginform" class="text-center border rounded-5 bg-body shadow p-5" role="form" method="POST" style="width: 25rem">
-            {% csrf_token %}
-            <div class="mb-5">
-                <span class="fs-1 text-body">Team</span><span class="fs-1 text-accent">Vault</span>
-            </div>
-            {% if form.errors %}
-                <p class="alert alert-danger text-break">{% trans "Your username and password didn't match. Please try again." %}</p>
-            {% endif %}
-            <div class="mb-2">
-                <input type="text" name="username" class="form-control" placeholder="{% trans "Username" %}"
-                       autocomplete="username" required autofocus>
-            </div>
-            <div class="mb-3">
-                <div class="input-group">
-                    <input type="password" name="password" class="form-control" placeholder="{% trans "Password" %}"
-                           autocomplete="current-password" required>
-                    <button form="loginform" class="btn btn-outline-accent" type="submit"><i
-                            class="fa fa-chevron-right"></i></button>
+        <div class="text-center border rounded-5 bg-body shadow p-5" style="width: 25rem">
+            <form id="loginform" method="POST">
+                {% csrf_token %}
+                <div class="mb-5">
+                    <span class="fs-1 text-body">Team</span><span class="fs-1 text-accent">Vault</span>
                 </div>
-            </div>
+                {% if form.errors %}
+                    <p class="alert alert-danger text-break">{% trans "Your username and password didn't match. Please try again." %}</p>
+                {% endif %}
+                <div class="mb-2">
+                    <input type="text" name="username" class="form-control" placeholder="{% trans "Username" %}"
+                           autocomplete="username" required autofocus>
+                </div>
+                <div class="mb-3">
+                    <div class="input-group">
+                        <input type="password" name="password" class="form-control" placeholder="{% trans "Password" %}"
+                               autocomplete="current-password" required>
+                        <button class="btn btn-outline-accent" type="submit">
+                            <i class="fa fa-chevron-right"></i>
+                        </button>
+                    </div>
+                </div>
+            </form>
             {% if google_auth_enabled %}
                 <p class="text-center">{% trans "or" %}</p>
-                <div class="d-grid">
-                    <a class="btn btn-outline-accent btn-lg"
-                       href="{% url "social:begin" "google-oauth2" %}?{{ request.GET.urlencode }}">
-                        <i class="fa-brands fa-google"></i> &nbsp;
+                <form id="googleform" method="POST" action="{% url "social:begin" "google-oauth2" %}">
+                    {% csrf_token %}
+                    <input type="hidden" name="next" value="{{ request.GET.next }}">
+                    <button type="submit" class="btn btn-outline-accent btn-lg w-100">
+                        <i class="fa-brands fa-google"></i>
                         {% trans "Sign in with Google" %}
-                    </a>
-                </div>
+                    </button>
+                </form>
             {% endif %}
-        </form>
+        </div>
     </div>
 {% endblock %}
-{% block footer %}{% endblock %}
+{% block footer %}
+{% endblock %}


### PR DESCRIPTION
# Context 
After the upgrade of social-auth-app-django to version 6.0.0 the login flow needs to be triggered by a POST not a GET-request. This is a documented [breaking change](https://github.com/python-social-auth/social-app-django/releases#release-6.0.0).

# Fix
A separate form in the login template with hidden input-fields sending the POST-request
## Reason for hidden input-fields
Due to the nature of do_auth() in social-core, which reads request.POST — not the URL query string — when the incoming request is a POST, the next redirect target must now be sent as a hidden form field instead of a query parameter. Otherwise it would silently be dropped and the user would land on the default LOGIN_REDIRECT_URL instead of their originally requested page.